### PR TITLE
implement experimental file caching hack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ host_utilization_layout.json
 
 #unit testing
 unit_tests
+
+#build directory
+build

--- a/include/wrench/services/compute/htcondor/HTCondorNegotiatorService.h
+++ b/include/wrench/services/compute/htcondor/HTCondorNegotiatorService.h
@@ -45,6 +45,8 @@ namespace wrench {
     private:
         int main() override;
 
+        std::vector<std::pair<WorkflowFile *, double>> listAllFilesAtStorageService(std::shared_ptr<StorageService> ss);
+
         struct JobPriorityComparator {
             bool operator()(std::tuple<std::shared_ptr<WorkflowJob>, std::map<std::string, std::string>> &lhs,
                             std::tuple<std::shared_ptr<WorkflowJob>, std::map<std::string, std::string>> &rhs);

--- a/include/wrench/services/storage/StorageService.h
+++ b/include/wrench/services/storage/StorageService.h
@@ -91,6 +91,7 @@ namespace wrench {
         friend class Simulation;
         friend class FileRegistryService;
         friend class FileTransferThread;
+        friend class HTCondorNegotiatorService;
 
         static void stageFile(WorkflowFile *file , std::shared_ptr<FileLocation> location);
 
@@ -100,9 +101,9 @@ namespace wrench {
         /** @brief File systems */
         std::map<std::string, std::unique_ptr<LogicalFileSystem>> file_systems;
 
+        std::map<WorkflowFile *, double> file_read_dates;
+
         /***********************/
-
-
         /** \endcond          **/
         /***********************/
 
@@ -119,6 +120,7 @@ namespace wrench {
         void stageFile(WorkflowFile *file , std::string mountpoint, std::string directory);
 
         bool is_stratch;
+
 
 
     };

--- a/include/wrench/services/storage/simple/SimpleStorageService.h
+++ b/include/wrench/services/storage/simple/SimpleStorageService.h
@@ -87,6 +87,7 @@ namespace wrench {
 
     private:
         friend class Simulation;
+        friend class HTCondorNegotiatorService;
 
         // Low-level Constructor
         SimpleStorageService(std::string hostname,
@@ -139,6 +140,7 @@ namespace wrench {
         void validateProperties();
 
         std::shared_ptr<MemoryManager> memory_manager;
+
 
     };
 

--- a/include/wrench/services/storage/storage_helpers/LogicalFileSystem.h
+++ b/include/wrench/services/storage/storage_helpers/LogicalFileSystem.h
@@ -58,6 +58,7 @@ namespace wrench {
     private:
 
         friend class StorageService;
+        friend class HTCondorNegotiatorService;
 
         void stageFile(WorkflowFile *file, std::string absolute_path);
 

--- a/include/wrench/simulation/Simulation.h
+++ b/include/wrench/simulation/Simulation.h
@@ -45,6 +45,8 @@ namespace wrench {
      */
     class Simulation {
 
+        friend class HTCondorNegotiatorService;
+
     public:
         Simulation();
 

--- a/src/wrench/services/compute/htcondor/HTCondorNegotiatorService.cpp
+++ b/src/wrench/services/compute/htcondor/HTCondorNegotiatorService.cpp
@@ -183,9 +183,10 @@ namespace wrench {
                                 // Copy input files to have a cached version available for the next task requiring this file
                                 bool found_a_location = false;
                                 //TODO: identify the most optimal source location
+                                // Read from the first source which has the file
                                 for (auto const &source_location : flp.second) {
                                     if (source_location->getStorageService()->lookupFile(flp.first, source_location)) {
-                                        StorageService::copyFile(flp.first, source_location, FileLocation::LOCATION(ss));
+                                        StorageService::copyFile(flp.first, source_location, FileLocation::LOCATION(ss)); //! decouple this from negotiation cycle
                                         found_a_location = true;
                                         break;
                                     }

--- a/src/wrench/services/compute/htcondor/HTCondorNegotiatorService.cpp
+++ b/src/wrench/services/compute/htcondor/HTCondorNegotiatorService.cpp
@@ -116,7 +116,7 @@ namespace wrench {
                         }
                     }
                     // adjust job's file_locations map
-                    for (auto ss : matched_local_storage_services) {
+                    for (auto const &ss : matched_local_storage_services) {
                         for (auto flp : sjob->file_locations) {
                             //TODO: make sure only input-files are required
                             if (!ss->lookupFile(flp.first, FileLocation::LOCATION(ss))) {
@@ -124,7 +124,18 @@ namespace wrench {
                                 //TODO: auto some_file = ss->getFileToEvict();
                                 //TODO: ss->deleteFile(some_file, FileLocation::LOCATION(ss));
                                 // Copy input files to have a cached version available for the next task requiring this file
-                                ss->writeFile(flp.first, FileLocation::LOCATION(ss));
+//                                ss->writeFile(flp.first, FileLocation::LOCATION(ss));
+                                bool found_a_location = false;
+                                for (auto const &source_location : flp.second) {
+                                    if (source_location->getStorageService()->lookupFile(flp.first, source_location)) {
+                                        StorageService::copyFile(flp.first, source_location, FileLocation::LOCATION(ss));
+                                        found_a_location = true;
+                                        break;
+                                    }
+                                }
+                                if (not found_a_location) {
+                                    throw std::runtime_error("Didn't find the file anywhere");
+                                }
                             }
                             flp.second.insert(flp.second.begin(), FileLocation::LOCATION(ss));
                         }

--- a/src/wrench/services/compute/htcondor/HTCondorNegotiatorService.cpp
+++ b/src/wrench/services/compute/htcondor/HTCondorNegotiatorService.cpp
@@ -188,6 +188,8 @@ namespace wrench {
                                 for (auto const &source_location : flp.second) {
                                     if (source_location->getStorageService()->lookupFile(flp.first, source_location)) {
                                         found_a_location = true;
+                                        //! temporary solution, since this doesn't take transfer time from remote to cache into account
+                                        //! the next job requiring this file might read it from cache, although it isn't transfered yet 
                                         StorageService::stageFile(flp.first, FileLocation::LOCATION(ss));
                                         file_in_cache = true;
                                         break;

--- a/src/wrench/services/compute/htcondor/HTCondorNegotiatorService.cpp
+++ b/src/wrench/services/compute/htcondor/HTCondorNegotiatorService.cpp
@@ -179,6 +179,7 @@ namespace wrench {
                                     if (need_evict_file) {
                                         std::cerr << "Need to evict file " << file_list.begin()->first->getID().c_str() << "on storage service " << ss->getName().c_str() << std::endl;
                                         ss->deleteFile(file_list.begin()->first, FileLocation::LOCATION(ss));
+                                        file_list.erase(file_list.begin());
                                     }
                                 }
                                 // Copy input files to have a cached version available for the next task requiring this file

--- a/src/wrench/services/storage/simple/SimpleStorageService.cpp
+++ b/src/wrench/services/storage/simple/SimpleStorageService.cpp
@@ -398,6 +398,10 @@ namespace wrench {
 
         // If success, then follow up with sending the file (ASYNCHRONOUSLY!)
         if (success) {
+
+            //
+            this->file_read_dates[file] = Simulation::getCurrentSimulatedDate();
+
             // Create a FileTransferThread
             auto ftt = std::shared_ptr<FileTransferThread>(
                     new FileTransferThread(this->hostname,


### PR DESCRIPTION
A first hack implementing a type of XRootD-ish input-file caching into the `HTCondorNegotiatorService`. Only at this point, the jobs' executing hosts can be identified and the jobs' file-location maps adjusted to read preferably from a local storage.